### PR TITLE
Processor refactoring

### DIFF
--- a/src/main/java/org/bric/core/model/DuplicateAction.java
+++ b/src/main/java/org/bric/core/model/DuplicateAction.java
@@ -1,0 +1,8 @@
+package org.bric.core.model;
+
+public enum DuplicateAction {
+
+    NOT_SET,
+    OVERWRITE, SKIP, RENAME, ADD,
+    ALWAYS_OVERWRITE, ALWAYS_SKIP, ALWAYS_RENAME, ALWAYS_ADD
+}

--- a/src/main/java/org/bric/gui/input/InputTab.java
+++ b/src/main/java/org/bric/gui/input/InputTab.java
@@ -16,8 +16,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -206,19 +204,12 @@ public class InputTab extends JPanel {
             return;
         }
 
-        ExecutorService executorService;
-        if (Utils.prefs.getInt("importNumThreads", 0) == 0) {
-            executorService = Executors.newWorkStealingPool(Runtime.getRuntime().availableProcessors());
-        } else {
-            executorService = Executors.newWorkStealingPool(Utils.prefs.getInt("importNumThreads", 1));
-        }
-
         final ProgressBarFrame importer = new ProgressBarFrame();
         importer.setImagesCount(imagesList.size());
         importer.setVisible(true);
 
         for (String s : imagesList) {
-            executorService.submit(importFile(importer, s));
+            Utils.getExecutorService().submit(importFile(importer, s));
         }
     }
 

--- a/src/main/java/org/bric/gui/input/InputTab.java
+++ b/src/main/java/org/bric/gui/input/InputTab.java
@@ -2,6 +2,7 @@ package org.bric.gui.input;
 
 import org.bric.core.input.DirectoryScanner;
 import org.bric.core.input.model.ImportedImage;
+import org.bric.core.model.DuplicateAction;
 import org.bric.gui.BricUI;
 import org.bric.gui.inputOutput.ProgressBarFrame;
 import org.bric.gui.swing.ArrayListTransferHandler;
@@ -28,7 +29,7 @@ public class InputTab extends JPanel {
     private javax.swing.JLabel itemsCountLabel;
     private final InputDetailsPanel inputDetailsPanel;
 
-    private int duplicateAction = Utils.NOT_SET;
+    private DuplicateAction duplicateAction = DuplicateAction.NOT_SET;
     private String lastOpenedDirectory = "";
 
     public InputTab() {
@@ -171,7 +172,7 @@ public class InputTab extends JPanel {
         itemsCountLabel.setText(bundle.getString("BricUI.itemsCountLabel.text") + model.getSize());
 
         if (model.getSize() == 0) {
-            duplicateAction = Utils.NOT_SET;
+            duplicateAction = DuplicateAction.NOT_SET;
         }
     }
 
@@ -219,8 +220,8 @@ public class InputTab extends JPanel {
                 duplicatePane(path);
             }
 
-            if (duplicateAction == Utils.SKIP ||
-                    duplicateAction == Utils.SKIP_ALL) {
+            if (duplicateAction == DuplicateAction.SKIP ||
+                    duplicateAction == DuplicateAction.ALWAYS_SKIP) {
                 progressBar.updateValue(true);
                 progressBar.showProgress(path);
                 return null;
@@ -256,14 +257,15 @@ public class InputTab extends JPanel {
 
     synchronized public void duplicatePane(String file) {
 
-        if (duplicateAction == Utils.NOT_SET || duplicateAction == Utils.REPLACE || duplicateAction == Utils.SKIP) {
+        if (duplicateAction == DuplicateAction.NOT_SET ||
+                duplicateAction == DuplicateAction.ADD ||
+                duplicateAction == DuplicateAction.SKIP) {
 
-            Object[] selectionValues = {bundle.getString("BricUI.duplicate.replaceAll"),
-                    bundle.getString("BricUI.duplicate.replace"),
-                    bundle.getString("BricUI.duplicate.skipAll"),
-                    bundle.getString("BricUI.duplicate.skip")};
-
-            String initialSelection = selectionValues[0].toString();
+            Object[] selectionValues = {
+                    DuplicateAction.ALWAYS_ADD,
+                    DuplicateAction.ADD,
+                    DuplicateAction.ALWAYS_SKIP,
+                    DuplicateAction.SKIP};
 
             Object selection;
 
@@ -271,34 +273,10 @@ public class InputTab extends JPanel {
                 selection = JOptionPane.showInputDialog(
                         null, String.format(bundle.getString("BricUI.duplicate.text"), "\n"+file+"\n"),
                         bundle.getString("BricUI.duplicate.title"), JOptionPane.QUESTION_MESSAGE,
-                        null, selectionValues, initialSelection);
+                        null, selectionValues, DuplicateAction.ALWAYS_ADD);
             } while(selection == null);
 
-            int answer = 0;
-            int i = 0;
-
-            for (Object value : selectionValues) {
-                if (selection == value.toString()) {
-                    answer = i;
-                }
-                i++;
-            }
-            switch (answer) {
-                case 0:
-                    duplicateAction = Utils.REPLACE_ALL;
-                    break;
-                case 1:
-                    duplicateAction = Utils.REPLACE;
-                    break;
-                case 2:
-                    duplicateAction = Utils.SKIP_ALL;
-                    break;
-                case 3:
-                    duplicateAction = Utils.SKIP;
-                    break;
-                default:
-                    duplicateAction = Utils.NOT_SET;
-            }
+            duplicateAction = (DuplicateAction) selection;
         }
     }
 }

--- a/src/main/java/org/bric/gui/inputOutput/ProgressBarFrame.java
+++ b/src/main/java/org/bric/gui/inputOutput/ProgressBarFrame.java
@@ -1,5 +1,6 @@
 package org.bric.gui.inputOutput;
 
+import org.bric.gui.BricUI;
 import org.bric.utils.Utils;
 
 import javax.swing.*;
@@ -25,6 +26,8 @@ public class ProgressBarFrame extends javax.swing.JFrame {
     private AtomicInteger errors;
     private long startTime;
     private int sleepValue;
+
+    private BricUI.CancelListener cancelListener;
     
     public ProgressBarFrame() {
         processed = new AtomicInteger(0);
@@ -33,7 +36,7 @@ public class ProgressBarFrame extends javax.swing.JFrame {
         sleepValue = Utils.prefs.getInt("sleepValue", 500);
         
         model = new DefaultListModel<>();
-        
+
         initComponents();
     }
     
@@ -149,6 +152,9 @@ public class ProgressBarFrame extends javax.swing.JFrame {
     }
 
     private void cancelButtonActionPerformed() {
+        if (cancelListener != null) {
+            cancelListener.canceled();
+        }
         this.dispose();
     }
 
@@ -207,11 +213,18 @@ public class ProgressBarFrame extends javax.swing.JFrame {
         } catch (InterruptedException ex) {
             Logger.getLogger(ProgressBarFrame.class.getName()).log(Level.SEVERE, null, ex);
         }
+        if (cancelListener != null) {
+            cancelListener.canceled();
+        }
         this.dispose();
     }
 
     @Override
     public void dispose() {
         super.dispose();
+    }
+
+    public void setCancelListener(BricUI.CancelListener cancelListener) {
+        this.cancelListener = cancelListener;
     }
 }

--- a/src/main/java/org/bric/processor/ImageProcessHandler.java
+++ b/src/main/java/org/bric/processor/ImageProcessHandler.java
@@ -65,7 +65,7 @@ public class ImageProcessHandler {
     public List<CompletableFuture<String>> start() {
         List<CompletableFuture<String>> futures = new ArrayList<>();
         if (outputParameters.getOutputType() == OutputType.PDF) {
-            generatePDF(inputQueue);
+            futures.add(CompletableFuture.supplyAsync(() -> generatePDF(inputQueue), Utils.getExecutorService()));
         } else {
             for (ImportedImage item : inputQueue) {
                 futures.add(CompletableFuture.supplyAsync(() -> task(item), Utils.getExecutorService()));
@@ -121,11 +121,11 @@ public class ImageProcessHandler {
         }
     }
 
-    public void generatePDF(List<ImportedImage> input) {
+    public String generatePDF(List<ImportedImage> input) {
         PDDocument document = new PDDocument();
 
         if (input.isEmpty()) {
-            return;
+            return "";
         }
 
         final ImportedImage firstItem = input.get(0);
@@ -150,6 +150,8 @@ public class ImageProcessHandler {
                 e.printStackTrace();
             }
         }
+
+        return firstItem.getPath();
     }
 
     private void notifyFileProcessed(ImportedImage importedImage) {

--- a/src/main/java/org/bric/processor/ImageProcessHandler.java
+++ b/src/main/java/org/bric/processor/ImageProcessHandler.java
@@ -65,7 +65,7 @@ public class ImageProcessHandler {
     public List<CompletableFuture<String>> start() {
         List<CompletableFuture<String>> futures = new ArrayList<>();
         if (outputParameters.getOutputType() == OutputType.PDF) {
-            futures.add(CompletableFuture.supplyAsync(() -> generatePdfFromPdf(inputQueue), Utils.getExecutorService()));
+            futures.add(CompletableFuture.supplyAsync(() -> mergeInputToSinglePdf(inputQueue), Utils.getExecutorService()));
         } else {
             for (ImportedImage item : inputQueue) {
                 futures.add(CompletableFuture.supplyAsync(() -> task(item), Utils.getExecutorService()));
@@ -77,7 +77,7 @@ public class ImageProcessHandler {
     private String task(final ImportedImage item) {
         if (item.getType() == InputType.PDF) {
             if (outputParameters.getOutputType() == OutputType.SAME_AS_FIRST) {
-                generatePdfFromPdf(Collections.singletonList(item));
+                mergeInputToSinglePdf(Collections.singletonList(item));
             } else {
                 generateImagesFromPdf(null, item);
             }
@@ -121,7 +121,7 @@ public class ImageProcessHandler {
         }
     }
 
-    public String generatePdfFromPdf(List<ImportedImage> input) {
+    public String mergeInputToSinglePdf(List<ImportedImage> input) {
         PDDocument document = new PDDocument();
 
         if (input.isEmpty()) {

--- a/src/main/java/org/bric/processor/ImageProcessHandler.java
+++ b/src/main/java/org/bric/processor/ImageProcessHandler.java
@@ -15,9 +15,6 @@ import org.bric.core.model.DuplicateAction;
 import org.bric.core.model.output.OutputParameters;
 import org.bric.core.model.output.OutputType;
 import org.bric.gui.BricUI;
-import org.bric.imageEditParameters.ResizeParameters;
-import org.bric.imageEditParameters.RotateParameters;
-import org.bric.imageEditParameters.WatermarkParameters;
 import org.bric.utils.Utils;
 
 import javax.imageio.IIOImage;
@@ -26,11 +23,9 @@ import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
 import javax.imageio.stream.FileImageOutputStream;
 import javax.swing.*;
-import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
@@ -57,67 +52,14 @@ public class ImageProcessHandler {
                 .collect(Collectors.toList());
 
         this.fileNameService = fileNameService;
-
     }
 
-    public static void preview(ImportedImage imageToPreview, ImageProcessor<?>... processors) {
-        File temporary;
-        try {
-            temporary = File.createTempFile("preview", ".jpg");
-            temporary.deleteOnExit();
-        } catch (IOException ex) {
-            Logger.getLogger(ImageProcessHandler.class.getName()).log(Level.SEVERE, null, ex);
-            return;
-        }
-
-        OutputParameters outputParameters = new OutputParameters(
-                temporary.getAbsolutePath().replace(".jpg", ""),
-                OutputType.JPG, 1, 1);
-        FileNameService fileNameService = new FileNameService(
-                outputParameters.getOutputPath(), outputParameters.getOutputType(),
-                outputParameters.getNumberingStartIndex(), 1);
-        ImageProcessHandler handler = new ImageProcessHandler(fileNameService, outputParameters,
-                Collections.singletonList(imageToPreview));
-        handler.addProcessors(processors);
-        handler.preview(temporary);
-    }
-
-    private void preview(File temporary) {
-        if (inputQueue.isEmpty()) {
-            return;
-        }
-
-        ImportedImage item = inputQueue.get(0);
-
-        if (item.getType() == InputType.PDF) {
-            JOptionPane.showMessageDialog(null, "PDF preview is not supported yet!");
-            return;
-        }
-
-        duplicateAction = DuplicateAction.ALWAYS_OVERWRITE;
-
-        try {
-            task(item);
-            Desktop.getDesktop().open(temporary);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+    public void setDuplicateAction(DuplicateAction duplicateAction) {
+        this.duplicateAction = duplicateAction;
     }
 
     public void addProcessors(ImageProcessor<?>... processors) {
         Collections.addAll(this.processors, processors);
-    }
-
-    public void setResizeParameters(ResizeParameters resizeParameters) {
-        processors.add(new ResizeProcessor(resizeParameters));
-    }
-
-    public void setRotateParameters(RotateParameters rotateParameters) {
-        processors.add(new RotateProcessor(rotateParameters));
-    }
-
-    public void setWatermarkParameters(WatermarkParameters watermarkParameters) {
-        processors.add(new WatermarkProcessor(watermarkParameters));
     }
 
     public List<CompletableFuture<String>> start() {
@@ -295,7 +237,7 @@ public class ImageProcessHandler {
             return;
         }
 
-        if( (duplicateAction == DuplicateAction.ADD || duplicateAction == DuplicateAction.ALWAYS_RENAME)
+        if( (duplicateAction == DuplicateAction.RENAME || duplicateAction == DuplicateAction.ALWAYS_RENAME)
                 && new File(newFilepath).exists()) {
             newFilepath = duplicateAddAction(newFilepath);
         }

--- a/src/main/java/org/bric/processor/ImageProcessHandler.java
+++ b/src/main/java/org/bric/processor/ImageProcessHandler.java
@@ -142,7 +142,7 @@ public class ImageProcessHandler {
             bufferedImageProcess(null, item, null);
         }
 
-        progressListener.finished(item.getPath());
+        notifyFileProcessed(item);
         return item.getPath();
     }
 
@@ -181,7 +181,7 @@ public class ImageProcessHandler {
     public void generatePDF(List<ImportedImage> input) {
         PDDocument document = new PDDocument();
 
-        if (input == null) {
+        if (input.isEmpty()) {
             return;
         }
 
@@ -193,7 +193,7 @@ public class ImageProcessHandler {
             } else {
                 bufferedImageProcess(document, importedImage, null);
             }
-            progressListener.finished(importedImage.getPath());
+            notifyFileProcessed(importedImage);
         }
 
         try {
@@ -207,6 +207,13 @@ public class ImageProcessHandler {
                 e.printStackTrace();
             }
         }
+    }
+
+    private void notifyFileProcessed(ImportedImage importedImage) {
+        if (progressListener == null) {
+            return;
+        }
+        progressListener.finished(importedImage.getPath());
     }
 
     public void addImageToPDF(PDDocument doc, BufferedImage image) {

--- a/src/main/java/org/bric/utils/Utils.java
+++ b/src/main/java/org/bric/utils/Utils.java
@@ -25,15 +25,6 @@ public class Utils {
     public static final Locale GREEK = new Locale("el", "GR");
     
     public static final String FS = System.getProperty("file.separator");
-    public static final int REPLACE_ALL = 0,
-            REPLACE = 1,
-            SKIP_ALL = 2,
-            SKIP = 3,
-            NOT_SET = 4,
-            OVERWRITE = 5,
-            OVERWRITE_ALL = 6,
-            ADD = 1,
-            ADD_ALL = 0;
     
     public static Preferences prefs = Preferences.userRoot();
     

--- a/src/main/java/org/bric/utils/Utils.java
+++ b/src/main/java/org/bric/utils/Utils.java
@@ -13,9 +13,14 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.prefs.Preferences;
 
 public class Utils {
+
+    private static final ExecutorService EXECUTOR_SERVICE =
+            Executors.newWorkStealingPool(Runtime.getRuntime().availableProcessors());
 
     public static final Locale GREEK = new Locale("el", "GR");
     
@@ -109,5 +114,9 @@ public class Utils {
         int x = (int) ((dimension.getWidth() - frame.getWidth()) / 2);
         int y = (int) ((dimension.getHeight() - frame.getHeight()) / 2);
         frame.setLocation(x, y);
+    }
+
+    public static ExecutorService getExecutorService() {
+        return EXECUTOR_SERVICE;
     }
 }

--- a/src/test-integration/java/org/bric/processor/ImageProcessHandlerIT.java
+++ b/src/test-integration/java/org/bric/processor/ImageProcessHandlerIT.java
@@ -10,9 +10,11 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.net.URL;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 public class ImageProcessHandlerIT {
 
@@ -24,90 +26,105 @@ public class ImageProcessHandlerIT {
     public Path outputPath;
 
     @Test
-    public void exportsImageToImage() throws InterruptedException {
+    public void exportsImageToImage() {
         List<ImportedImage> input = Collections.singletonList(new ImportedImage(file(DUCK_JPG).getAbsolutePath()));
         OutputParameters output = new OutputParameters(outputPath.resolve("out*").toString(), OutputType.JPG, 1, 1);
 
-        new ImageProcessHandler(getFileNameService(output, input), output, input).start();
+        ImageProcessHandler handler = new ImageProcessHandler(getFileNameService(output, input), output, input);
 
-        Thread.sleep(1000);
-        Assertions.assertTrue(outputPath.resolve("out1.jpg").toFile().exists());
+        Assertions.assertTimeout(Duration.ofSeconds(3), () -> {
+            CompletableFuture.allOf(handler.start().toArray(new CompletableFuture[0])).get();
+            Assertions.assertTrue(outputPath.resolve("out1.jpg").toFile().exists());
+        });
     }
 
     @Test
-    public void exportsImageToPdf() throws InterruptedException {
+    public void exportsImageToPdf() {
         List<ImportedImage> input = Collections.singletonList(new ImportedImage(file(DUCK_JPG).getAbsolutePath()));
         OutputParameters output = new OutputParameters(outputPath.resolve("out*").toString(), OutputType.PDF, 1, 1);
 
-        new ImageProcessHandler(getFileNameService(output, input), output, input).start();
+        ImageProcessHandler handler = new ImageProcessHandler(getFileNameService(output, input), output, input);
 
-        Thread.sleep(1000);
-        Assertions.assertTrue(outputPath.resolve("out1.pdf").toFile().exists());
+        Assertions.assertTimeout(Duration.ofSeconds(3), () -> {
+            CompletableFuture.allOf(handler.start().toArray(new CompletableFuture[0])).get();
+            Assertions.assertTrue(outputPath.resolve("out1.pdf").toFile().exists());
+        });
     }
 
     @Test
-    public void exportsEachPdfPageToImage() throws InterruptedException {
+    public void exportsEachPdfPageToImage() {
         List<ImportedImage> input = Collections.singletonList(new ImportedImage(file(TWO_PAGE_PDF).getAbsolutePath()));
         OutputParameters output = new OutputParameters(outputPath.resolve("page*").toString(), OutputType.JPG, 1, 1);
 
-        new ImageProcessHandler(getFileNameService(output, input), output, input).start();
+        ImageProcessHandler handler = new ImageProcessHandler(getFileNameService(output, input), output, input);
 
-        Thread.sleep(2000);
-        Assertions.assertTrue(outputPath.resolve("page1.jpg").toFile().exists());
-        Assertions.assertTrue(outputPath.resolve("page2.jpg").toFile().exists());
+        Assertions.assertTimeout(Duration.ofSeconds(3), () -> {
+            CompletableFuture.allOf(handler.start().toArray(new CompletableFuture[0])).get();
+            Assertions.assertTrue(outputPath.resolve("page1.jpg").toFile().exists());
+            Assertions.assertTrue(outputPath.resolve("page2.jpg").toFile().exists());
+        });
     }
 
     @Test
-    public void exportsEachPdfToItsOwnPdf() throws InterruptedException {
+    public void exportsEachPdfToItsOwnPdf() {
         List<ImportedImage> input = Arrays.asList(
                 new ImportedImage(file(TWO_PAGE_PDF).getAbsolutePath()),
                 new ImportedImage(file(TWO_PAGE_PDF).getAbsolutePath()));
         OutputParameters output = new OutputParameters(outputPath.resolve("out*").toString(), OutputType.SAME_AS_FIRST, 1, 1);
 
-        new ImageProcessHandler(getFileNameService(output, input), output, input).start();
+        ImageProcessHandler handler = new ImageProcessHandler(getFileNameService(output, input), output, input);
 
-        Thread.sleep(2000);
-        Assertions.assertTrue(outputPath.resolve("out1.pdf").toFile().exists());
-        Assertions.assertTrue(outputPath.resolve("out2.pdf").toFile().exists());
+        Assertions.assertTimeout(Duration.ofSeconds(3), () -> {
+            CompletableFuture.allOf(handler.start().toArray(new CompletableFuture[0])).get();
+            Assertions.assertTrue(outputPath.resolve("out1.pdf").toFile().exists());
+            Assertions.assertTrue(outputPath.resolve("out2.pdf").toFile().exists());
+        });
     }
 
     @Test
-    public void mergesImagesToASinglePdf() throws InterruptedException {
+    public void mergesImagesToASinglePdf() {
         List<ImportedImage> input = Arrays.asList(
                 new ImportedImage(file(DUCK_JPG).getAbsolutePath()),
                 new ImportedImage(file(DOG_JPEG).getAbsolutePath()));
         OutputParameters output = new OutputParameters(outputPath.resolve("out*").toString(), OutputType.PDF, 1, 1);
 
-        new ImageProcessHandler(getFileNameService(output, input), output, input).start();
+        ImageProcessHandler handler = new ImageProcessHandler(getFileNameService(output, input), output, input);
 
-        Thread.sleep(1000);
-        Assertions.assertTrue(outputPath.resolve("out1.pdf").toFile().exists());
+
+        Assertions.assertTimeout(Duration.ofSeconds(3), () -> {
+            CompletableFuture.allOf(handler.start().toArray(new CompletableFuture[0])).get();
+            Assertions.assertTrue(outputPath.resolve("out1.pdf").toFile().exists());
+        });
     }
 
     @Test
-    public void mergesPdfPagesToASinglePdf() throws InterruptedException {
+    public void mergesPdfPagesToASinglePdf() {
         List<ImportedImage> input = Collections.singletonList(new ImportedImage(file(TWO_PAGE_PDF).getAbsolutePath()));
         OutputParameters output = new OutputParameters(outputPath.resolve("out*").toString(), OutputType.PDF, 1, 1);
 
-        new ImageProcessHandler(getFileNameService(output, input), output, input).start();
+        ImageProcessHandler handler = new ImageProcessHandler(getFileNameService(output, input), output, input);
 
-        Thread.sleep(1000);
-        Assertions.assertTrue(outputPath.resolve("out1.pdf").toFile().exists());
-        Assertions.assertFalse(outputPath.resolve("out2.pdf").toFile().exists());
+        Assertions.assertTimeout(Duration.ofSeconds(3), () -> {
+            CompletableFuture.allOf(handler.start().toArray(new CompletableFuture[0])).get();
+            Assertions.assertTrue(outputPath.resolve("out1.pdf").toFile().exists());
+            Assertions.assertFalse(outputPath.resolve("out2.pdf").toFile().exists());
+        });
     }
 
     @Test
-    public void mergesPdfAndImagesToASinglePdf() throws InterruptedException {
+    public void mergesPdfAndImagesToASinglePdf() {
         List<ImportedImage> input = Arrays.asList(
                 new ImportedImage(file(DUCK_JPG).getAbsolutePath()),
                 new ImportedImage(file(TWO_PAGE_PDF).getAbsolutePath()));
         OutputParameters output = new OutputParameters(outputPath.resolve("out*").toString(), OutputType.PDF, 1, 1);
 
-        new ImageProcessHandler(getFileNameService(output, input), output, input).start();
+        ImageProcessHandler handler = new ImageProcessHandler(getFileNameService(output, input), output, input);
 
-        Thread.sleep(1000);
-        Assertions.assertTrue(outputPath.resolve("out1.pdf").toFile().exists());
-        Assertions.assertFalse(outputPath.resolve("out2.pdf").toFile().exists());
+        Assertions.assertTimeout(Duration.ofSeconds(3), () -> {
+            CompletableFuture.allOf(handler.start().toArray(new CompletableFuture[0])).get();
+            Assertions.assertTrue(outputPath.resolve("out1.pdf").toFile().exists());
+            Assertions.assertFalse(outputPath.resolve("out2.pdf").toFile().exists());
+        });
     }
 
     private File file(String name) {


### PR DESCRIPTION
Remove direct access of progress bar from processor
Move preview from processor to main window
Make single PDF generation non blocking
Use enum for duplicate actions
Use timeout on tests instead of sleep
Use functional style to remove complicated output behavior